### PR TITLE
Update PayParkingMeterActivity to implement fixed cost for 2 hours 30…

### DIFF
--- a/app/src/main/java/com/example/cs4360app/activities/PayParkingMeterActivity.kt
+++ b/app/src/main/java/com/example/cs4360app/activities/PayParkingMeterActivity.kt
@@ -18,7 +18,9 @@ class PayParkingMeterActivity : AppCompatActivity() {
     private lateinit var startBudgetSimulatorButton: Button
     private lateinit var backButton: Button
 
-    private val ratePerMinute = 5.35f / 150 // $5.35 for 2 hours and 30 minutes (150 minutes)
+    private val commonCost = 5.35f // Fixed cost for 2 hours and 30 minutes (150 minutes)
+    private val maxMinutes = 240 // Maximum parking time in minutes (4 hours)
+    private val baseMinutes = 150 // Base time (2 hours 30 minutes)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,7 +34,7 @@ class PayParkingMeterActivity : AppCompatActivity() {
         backButton = findViewById(R.id.back_button)
 
         // Set up SeekBar listener
-        parkingDurationSeekBar.max = 240 // Maximum of 4 hours
+        parkingDurationSeekBar.max = maxMinutes // Maximum of 4 hours (240 minutes)
         parkingDurationSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             @SuppressLint("SetTextI18n")
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
@@ -89,6 +91,12 @@ class PayParkingMeterActivity : AppCompatActivity() {
     }
 
     private fun calculatePayment(minutes: Int): Float {
-        return (minutes * ratePerMinute)
+        return if (minutes <= baseMinutes) {
+            commonCost // If the time is within or equal to 2 hours and 30 minutes, charge $5.35
+        } else {
+            // Additional cost for any time beyond the base time (2 hours 30 minutes)
+            val extraMinutes = minutes - baseMinutes
+            commonCost + (extraMinutes * (commonCost / baseMinutes)) // Pro-rated extra time
+        }
     }
 }

--- a/app/src/main/res/layout/activity_pay_parking_meter.xml
+++ b/app/src/main/res/layout/activity_pay_parking_meter.xml
@@ -21,7 +21,7 @@
         android:id="@+id/cost_per_hour_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Cost per hour: $5.35"
+        android:text="Cost for 2 hours 30 minutes: $5.35"
         tools:ignore="HardcodedText" />
 
     <TextView


### PR DESCRIPTION
… minutes

Commit Description:

	•	Implemented a fixed cost of $5.35 for parking up to 2 hours and 30 minutes (150 minutes) in PayParkingMeterActivity.
	•	Updated the cost calculation logic to pro-rate additional time beyond the base 150 minutes.
	•	Modified the SeekBar to allow users to select up to 4 hours of parking time, with dynamic updates for selected time and total cost.
	•	Updated the layout to display a fixed cost label for the 2-hour 30-minute period and adjusted the UI for better user feedback.
	•	Ensured that parking durations below 15 minutes are not allowed and provided validation to notify users.
	•	Simplified cost calculations and displayed the pro-rated cost dynamically based on user selection.